### PR TITLE
Implement asArabic using an iterator (and without streams)

### DIFF
--- a/src/main/java/tudelft/roman/RomanNumeral.java
+++ b/src/main/java/tudelft/roman/RomanNumeral.java
@@ -1,24 +1,27 @@
 package tudelft.roman;
 
+import java.text.CharacterIterator;
+import java.text.StringCharacterIterator;
 import java.util.Map;
 
 public class RomanNumeral {
-    private final static Map<Character, Integer> CHAR_TO_DIGIT = Map.of('I', 1, 'V', 5, 'X', 10, 'L', 50, 'C', 100, 'D', 500, 'M', 1000);
+    private final static Map<Character, Integer> RomanToArabic = 
+            Map.of('I', 1, 'V', 5, 'X', 10, 'L', 50, 'C', 100, 'D', 500, 'M', 1000);
 
     public int asArabic(String roman) {
-        final var digits = roman.chars().map(c -> CHAR_TO_DIGIT.get((char)c)).toArray();
+        final var iter = new StringCharacterIterator(roman);
 
+        var nextValue = 0;
         var result = 0;
-        for(int i = 0; i < digits.length; i++) {
-            final var currentNumber = digits[i];
-            result += isSubtractive(digits, i, currentNumber) ? -currentNumber : currentNumber;
+        for (char c = iter.last(); c != CharacterIterator.DONE; c = iter.previous()) {
+            var currentValue = RomanToArabic.get(c);
+            var isSubtractive = currentValue < nextValue;
+            var factor = isSubtractive ? -1 : 1;
+            result += factor * currentValue;
+
+            nextValue = currentValue;
         }
 
         return result;
-    }
-
-    private static boolean isSubtractive(int[] digits, int i, int currentNumber) {
-        return i + 1 < digits.length
-            && currentNumber < digits[i + 1];
     }
 }

--- a/src/main/java/tudelft/roman/RomanNumeralWithStream.java
+++ b/src/main/java/tudelft/roman/RomanNumeralWithStream.java
@@ -1,0 +1,31 @@
+package tudelft.roman;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+
+public class RomanNumeralWithStream {
+    private final static Map<Character, Integer> RomanToArabic = 
+            Map.of('I', 1, 'V', 5, 'X', 10, 'L', 50, 'C', 100, 'D', 500, 'M', 1000);
+
+    public int asArabic(String roman) {
+        // Create a new array with every roman numeral converted to the corresponding number,
+        // with a zero (0) appended at the end.
+        // (The char conversion is needed because String.chars() returns an IntStream.)
+        final var numbers = 
+            IntStream.concat(
+                roman.chars().mapToObj(i -> (char) i).mapToInt(RomanToArabic::get),
+                IntStream.of(0)).toArray();
+        
+        var previousNumber = -1;
+        var result = 0;
+        for (var currentNumber : numbers) {
+            if (previousNumber != -1) {
+                var isSubtractive = previousNumber < currentNumber;
+                var factor = isSubtractive ? -1 : 1;
+                result += factor * previousNumber;
+            }
+            previousNumber = currentNumber;
+        }
+        return result;
+    }
+}

--- a/src/test/java/tudelft/roman/RomanNumeralTest.java
+++ b/src/test/java/tudelft/roman/RomanNumeralTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class RomanNumeralTest {
-
-
     @Test
     public void singleNumber() {
         var roman = new RomanNumeral();

--- a/src/test/java/tudelft/roman/RomanNumeralTestWithSetup.java
+++ b/src/test/java/tudelft/roman/RomanNumeralTestWithSetup.java
@@ -3,12 +3,18 @@ package tudelft.roman;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class RomanNumeralTestWithBeforeEach {
-/*
-  JUnit creates a new instance of the class before each test,
-  so test setup can be assigned as instance fields.
-  This has the advantage that references can be made final
+/**
+ * Tests the RomanNumeral class.
+ * You can also use this test class to test the 
+ * RomanNumeralWithStream implementation.
+ *
  */
+public class RomanNumeralTestWithSetup {
+    /*
+      JUnit creates a new instance of the class before each test,
+      so test setup can be assigned as instance fields.
+      This has the advantage that references can be made final.
+     */
     final private RomanNumeral roman = new RomanNumeral();
 
     @Test


### PR DESCRIPTION
This is an attempt to make the code of the RomanNumeral example look more like idiomatic Java. We use standard Java classes here, and iterate backwards through the string to save us from the array bounds checks.