### PR TITLE
Added Tax Income Exercise, Tests & Markdown file

### DIFF
--- a/docs/TaxIncome.md
+++ b/docs/TaxIncome.md
@@ -1,0 +1,71 @@
+# Tax Income
+
+#### Requirement
+
+*Your income is taxed as follows:*
+> * `0 <= Income < 22100` → **Tax = `0.15 x Income`**
+> * `22100 <= Income < 53500` → **Tax = `3315 + 0.28 * (Income - 22100)`**
+> * `53500 <= Income < 115000` → **Tax = `12107 + 0.31 * (Income - 53500)`**
+> * `115000 <= Income < 250000` → **Tax = `31172 + 0.36 * (Income - 115000)`**
+> * `250000 <= Income` → **Tax = `79772 + 0.396 * (Income - 250000)`**
+
+#### Variables, Types, Ranges
+
+| Variable | Type | Range | Remark |
+| -------- | ---- | ----- | ------ |
+| Income | double | `[0, infinite]` | input |
+| Tax | double | `[0, infinite]` | output |
+
+#### Dependency between variables
+
+*Income is used to calculate Tax*
+
+#### Equivalence partitioning / Boundary analysis
+
+| Variable | Equivalence classes | Invalid classes | Boundaries | Remark |
+| -------- | ------------------- | --------------- | ---------- | ------ |
+| Income | [0, 22100[ | | -1 | negative number |
+|  | | | 0 | |
+|  | | | 22099 | 22099.99 is better! |
+|  | | | 22100 | |
+| | | | | |
+| | [22100,53500[ | | 22099 | |
+|  | | | 22100 | |
+|  | | | 53499 | |
+|  | | | 53500 | |
+| | | | | |
+| | [53500,115000[ | | 53499 | |
+|  | | | 53500 | |
+|  | | | 114999 | |
+|  | | | 115000 | |
+| | | | | |
+| | [115000,250000[ | | 114999 | |
+|  | | | 115000 | |
+|  | | | 250000 | |
+|  | | | 250001 | |
+| | | | | |
+| | [250000, infinite[ | | 249999 | |
+|  | | | 250000 | |
+
+#### Strategy
+
+*Test the boundaries (removing duplicates) → 10 tests*
+
+#### Test cases
+
+|  #  | Income | Tax |
+| --- | ------ | --- |
+| T1 | -1 | *CANNOT CALC TAX* |
+| T2 | 0 | 0 |
+| T3 | 22099 | 3314.85 |
+| T4 | 22100 | 3315 |
+| T5 | 53499 | 12106.72 |
+| T6 | 53500 | 12107 |
+| T7 | 114999 | 31171.69 |
+| T8 | 115000 | 31172 |
+| T9 | 249999 | 79771.64 |
+| T10 | 250000 | 79772 |
+
+#### Question
+
+*Would you consider 22100 and 22099 a duplicate?*

--- a/src/main/java/tudelft/domain/TaxIncome.java
+++ b/src/main/java/tudelft/domain/TaxIncome.java
@@ -1,0 +1,27 @@
+package tudelft.domain;
+
+public class TaxIncome {
+
+    public static final double CANNOT_CALC_TAX = -1;
+
+    public double calculate(double income) {
+        if (0 <= income && income < 22100) {
+            return 0.15 * income;
+        }
+        else if (22100 <= income && income < 53500) {
+            return 3315 + 0.28 * (income - 22100);
+        }
+        else if (53500 <= income && income < 115000) {
+            return 12107 + 0.31 * (income - 53500);
+        }
+        else if (115000 <= income && income < 250000) {
+            return 31172 + 0.36 * (income - 115000);
+        }
+        else if (250000 <= income) {
+            return 79772 + 0.396 * (income - 250000);
+        }
+
+        return CANNOT_CALC_TAX;
+    }
+
+}

--- a/src/test/java/tudelft/domain/TaxIncomeTest.java
+++ b/src/test/java/tudelft/domain/TaxIncomeTest.java
@@ -1,0 +1,43 @@
+package tudelft.domain;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class TaxIncomeTest {
+
+    @ParameterizedTest
+    @MethodSource("generator")
+    void boundaries(double income, double expectedResult) {
+        double result = new TaxIncome().calculate(income);
+        Assertions.assertEquals(expectedResult, result);
+    }
+
+    // Income Tax Brackets
+
+    // B1: 0 <= Income < 22100 -> 0.15 x Income
+    // B2: 22100 <= Income < 53500 -> 3315 + 0.28 * (Income - 22100)
+    // B3: 53500 <= Income < 115000 -> 12107 + 0.31 * (Income - 53500)
+    // B4: 115000 <= Income < 250000 -> 31172 + 0.36 * (Income - 115000)
+    // B5: 250000 <= Income -> 79772 + 0.396 * (Income - 250000)
+
+    private static Stream<Arguments> generator() {
+        return Stream.of(
+            Arguments.of(-1, TaxIncome.CANNOT_CALC_TAX),            // T1: OFF Point B1 lower
+            Arguments.of(0, 0),                                     // T2: ON Point B1 lower
+            Arguments.of(22099, 0.15 * 22099),                      // T3: OFF Point B1 upper & B2 lower
+            Arguments.of(22100, 3315),                              // T4: ON Point B1 upper & B2 lower
+            Arguments.of(53499, 3315 + 0.28 * (53499 - 22100)),     // T5: OFF Point B2 upper & B3 lower
+            Arguments.of(53500, 12107),                             // T6: ON Point B2 upper & B3 lower
+            Arguments.of(114999, 12107 + 0.31 * (114999 - 53500)),  // T7: OFF Point B3 upper & B4 lower
+            Arguments.of(115000, 31172),                            // T8: ON Point B3 upper & B4 lower
+            Arguments.of(249999, 31172 + 0.36 * (249999 - 115000)), // T9: OFF Point B4 upper & B5 lower
+            Arguments.of(250000, 79772)                             // T10: ON Point B4 upper & B5 lower
+        );
+
+    }
+
+}


### PR DESCRIPTION
Contains a few changes from the spreadsheet, including:

- the lower bound for the first tax bracket is now <= 0, instead of 0, since 0 is a valid input anyway;
- if an invalid (< 0) input is given, a static final double CANNOT_CALC_TAX with the value of -1 is returned (similar to the chocolate example);
- modified a few of the test cases;